### PR TITLE
[Feat] #27 - 등록 뷰 이미지 작업

### DIFF
--- a/Napzakmarket-iOS/Napzakmarket-iOS.xcodeproj/project.pbxproj
+++ b/Napzakmarket-iOS/Napzakmarket-iOS.xcodeproj/project.pbxproj
@@ -31,9 +31,9 @@
 		6C412F5D2D37DFC200998B27 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0AA20FA2D2C0B96004CC2E6 /* TabBarView.swift */; };
 		6C693D132D2D7C2600758C6A /* TextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C693D122D2D7C2600758C6A /* TextField+.swift */; };
 		6C71799E2D36118B00481622 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C71799D2D36118B00481622 /* String+.swift */; };
+		6C7179A22D36955C00481622 /* RegisterBuyPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7179A12D36955C00481622 /* RegisterBuyPrice.swift */; };
 		D02CAB5C2D34A9CC00B0D93F /* ProductItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02CAB5B2D34A9C200B0D93F /* ProductItemView.swift */; };
 		D02CAB612D34EBAB00B0D93F /* NZSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02CAB602D34EB9C00B0D93F /* NZSegmentedControl.swift */; };
-		6C7179A22D36955C00481622 /* RegisterBuyPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7179A12D36955C00481622 /* RegisterBuyPrice.swift */; };
 		D07A11F82D301BF400749962 /* ColorLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07A11F72D301BE300749962 /* ColorLiteral.swift */; };
 		D07B6F282D30001700500B92 /* NapzakTextStyleModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07B6F272D30000900500B92 /* NapzakTextStyleModifier.swift */; };
 		D07B6F2A2D30017E00500B92 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07B6F292D30017B00500B92 /* View+.swift */; };
@@ -88,9 +88,9 @@
 		6C693D122D2D7C2600758C6A /* TextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+.swift"; sourceTree = "<group>"; };
 		6C693D142D2E4D9200758C6A /* TextEditor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextEditor+.swift"; sourceTree = "<group>"; };
 		6C71799D2D36118B00481622 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		6C7179A12D36955C00481622 /* RegisterBuyPrice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterBuyPrice.swift; sourceTree = "<group>"; };
 		D02CAB5B2D34A9C200B0D93F /* ProductItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductItemView.swift; sourceTree = "<group>"; };
 		D02CAB602D34EB9C00B0D93F /* NZSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NZSegmentedControl.swift; sourceTree = "<group>"; };
-		6C7179A12D36955C00481622 /* RegisterBuyPrice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterBuyPrice.swift; sourceTree = "<group>"; };
 		D07A11F72D301BE300749962 /* ColorLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorLiteral.swift; sourceTree = "<group>"; };
 		D07B6F272D30000900500B92 /* NapzakTextStyleModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NapzakTextStyleModifier.swift; sourceTree = "<group>"; };
 		D07B6F292D30017B00500B92 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
@@ -680,9 +680,7 @@
 				6C2D5B662D32B47B00E904C6 /* RegisterImage.swift in Sources */,
 				3CF80DC22D3697C900E8DE1F /* MyPageFeature.swift in Sources */,
 				6C2D5B6A2D32B62000E904C6 /* RegisterTitle.swift in Sources */,
-				D0AA210E2D2C0C49004CC2E6 /* SearchView.swift in Sources */,
 				D02CAB612D34EBAB00B0D93F /* NZSegmentedControl.swift in Sources */,
-				6C693D152D2E4D9200758C6A /* TextEditor+.swift in Sources */,
 				6C2D5B7B2D32C2A800E904C6 /* RegisterBuyHeader.swift in Sources */,
 				6C693D132D2D7C2600758C6A /* TextField+.swift in Sources */,
 				3CF80DC02D3696F300E8DE1F /* MypageView.swift in Sources */,

--- a/Napzakmarket-iOS/Napzakmarket-iOS.xcodeproj/project.pbxproj
+++ b/Napzakmarket-iOS/Napzakmarket-iOS.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		6C693D132D2D7C2600758C6A /* TextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C693D122D2D7C2600758C6A /* TextField+.swift */; };
 		6C71799E2D36118B00481622 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C71799D2D36118B00481622 /* String+.swift */; };
 		6C7179A22D36955C00481622 /* RegisterBuyPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7179A12D36955C00481622 /* RegisterBuyPrice.swift */; };
+		6CA556E42D38E11700AD1CF6 /* RegisterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA556E32D38E11700AD1CF6 /* RegisterModel.swift */; };
 		D02CAB5C2D34A9CC00B0D93F /* ProductItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02CAB5B2D34A9C200B0D93F /* ProductItemView.swift */; };
 		D02CAB612D34EBAB00B0D93F /* NZSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02CAB602D34EB9C00B0D93F /* NZSegmentedControl.swift */; };
 		D07A11F82D301BF400749962 /* ColorLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07A11F72D301BE300749962 /* ColorLiteral.swift */; };
@@ -89,6 +90,7 @@
 		6C693D142D2E4D9200758C6A /* TextEditor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextEditor+.swift"; sourceTree = "<group>"; };
 		6C71799D2D36118B00481622 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		6C7179A12D36955C00481622 /* RegisterBuyPrice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterBuyPrice.swift; sourceTree = "<group>"; };
+		6CA556E32D38E11700AD1CF6 /* RegisterModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterModel.swift; sourceTree = "<group>"; };
 		D02CAB5B2D34A9C200B0D93F /* ProductItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductItemView.swift; sourceTree = "<group>"; };
 		D02CAB602D34EB9C00B0D93F /* NZSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NZSegmentedControl.swift; sourceTree = "<group>"; };
 		D07A11F72D301BE300749962 /* ColorLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorLiteral.swift; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 		6C2D5B582D32AD2800E904C6 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				6CA556E32D38E11700AD1CF6 /* RegisterModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -685,6 +688,7 @@
 				6C693D132D2D7C2600758C6A /* TextField+.swift in Sources */,
 				3CF80DC02D3696F300E8DE1F /* MypageView.swift in Sources */,
 				D63F2FCC2D369B9C00C1C7D1 /* AppEntryView.swift in Sources */,
+				6CA556E42D38E11700AD1CF6 /* RegisterModel.swift in Sources */,
 				D6C6750E2D32A5BB00DE6B4D /* Genre.swift in Sources */,
 				D6F528A72D362ABF00D1F7A8 /* GenreChip.swift in Sources */,
 				D6F528C32D36503B00D1F7A8 /* OnboardingView.swift in Sources */,

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Global/Resources/Assets.xcassets/Register/ic_x_circle_black.imageset/Contents.json
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Global/Resources/Assets.xcassets/Register/ic_x_circle_black.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_x_circle_black.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Global/Resources/Assets.xcassets/Register/ic_x_circle_black.imageset/ic_x_circle_black.svg
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Global/Resources/Assets.xcassets/Register/ic_x_circle_black.imageset/ic_x_circle_black.svg
@@ -1,0 +1,5 @@
+<svg width="23" height="25" viewBox="0 0 23 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12.2979" cy="12.8545" r="11" fill="#7B7B7B"/>
+<path d="M8.6311 9.18799L15.9644 16.5213" stroke="white" stroke-width="1.83333" stroke-linecap="round"/>
+<path d="M15.9644 9.18799L8.63102 16.5213" stroke="white" stroke-width="1.83333" stroke-linecap="round"/>
+</svg>

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/Buy/RegisterBuyHeader.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/Buy/RegisterBuyHeader.swift
@@ -42,8 +42,3 @@ struct RegisterBuyHeader: View {
         Divider()
     }
 }
-
-#Preview {
-    @State var state = false
-    RegisterView(registerType: $state)
-}

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/Buy/RegisterBuyHeader.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/Buy/RegisterBuyHeader.swift
@@ -11,27 +11,39 @@ struct RegisterBuyHeader: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        HStack{
-            Button {
-                dismiss()
-            } label: {
-                Image(systemName: "xmark")
-            }
-            .frame(width: 24, height: 24)
-            .foregroundStyle(Color.napzakGrayScale(.gray900))
-            
-            Spacer()
-            
-            Text("구해요 등록")
-                .font(.napzakFont(.title5SemiBold18))
-                .applyNapzakTextStyle(napzakFontStyle: .title5SemiBold18)
+        ZStack{
+            HStack {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .frame(width: 24, height: 24)
                 .foregroundStyle(Color.napzakGrayScale(.gray900))
+                
+                Spacer()
+            }
+            .padding(.leading, 20)
             
-            Spacer()
+            HStack {
+                Spacer()
+                
+                Text("구해요 등록")
+                    .font(.napzakFont(.title5SemiBold18))
+                    .applyNapzakTextStyle(napzakFontStyle: .title5SemiBold18)
+                    .foregroundStyle(Color.napzakGrayScale(.gray900))
+                
+                Spacer()
+            }
+            .padding(.vertical, 10)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 5)
+
         
         Divider()
     }
+}
+
+#Preview {
+    @State var state = false
+    RegisterView(registerType: $state)
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterGenre.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterGenre.swift
@@ -15,24 +15,33 @@ struct RegisterGenre: View {
             RegisterSearch(genre: $genre)
                 
         } label: {
-            HStack {
-                Text("장르")
-                    .foregroundStyle(Color.napzakGrayScale(.gray900))
-                Spacer()
-                Text(genre)
-                    .foregroundStyle(Color.napzakPurple(.purple30))
+            VStack(spacing: 0){
+                HStack(alignment: .center) {
+                    Text("장르")
+                        .foregroundStyle(Color.napzakGrayScale(.gray900))
+                    Spacer()
+                    Text(genre)
+                        .foregroundStyle(Color.napzakPurple(.purple30))
+                    
+                    Image(systemName: "chevron.right")
+                        .foregroundStyle(Color.napzakGrayScale(.gray400))
+                }
+                .font(.napzakFont(.body2SemiBold16))
+                .applyNapzakTextStyle(napzakFontStyle: .body2SemiBold16)
+                .padding(.bottom, 20)
                 
-                Image(systemName: "chevron.right")
-                    .foregroundStyle(Color.napzakGrayScale(.gray400))
+                HStack{
+                    
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 1)
+                .background(Color.napzakGrayScale(.gray200))
+
             }
-            .font(.napzakFont(.body2SemiBold16))
-            .applyNapzakTextStyle(napzakFontStyle: .body2SemiBold16)
         }
         .padding(20)
         
-        Divider()
-            .frame(height: 1)
-            .background(Color.napzakGrayScale(.gray200))
-            .padding(.horizontal, 20)
+        
     }
 }
+

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -25,7 +25,8 @@ struct RegisterImage: View {
                 .foregroundStyle(Color.napzakGrayScale(.gray600))
             
             ScrollView(.horizontal) {
-                HStack{
+                HStack {
+                    // 사진 선택 버튼
                     PhotosPicker(
                         selection: $photosPickerItem,
                         maxSelectionCount: 10-images.count,
@@ -49,18 +50,18 @@ struct RegisterImage: View {
                         .background(Color.napzakGrayScale(.gray100))
                         .foregroundStyle(Color.napzakGrayScale(.gray500))
                         .clipShape(RoundedRectangle(cornerRadius: 12))
-                        .padding(.top, 12)
                     }
                     
                     ForEach(0..<images.count, id: \.self) { i in
                         Image(uiImage: images[i])
                             .resizable()
-                            .scaledToFit()
+                            .scaledToFill()
                             .frame(width: 80, height: 80)
                             .clipShape(RoundedRectangle(cornerRadius: 12))
-                        
                     }
                 }
+                .padding(.top, 12)
+
             }
             
         }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -65,6 +65,20 @@ struct RegisterImage: View {
                                 .onTapGesture {
                                     images.remove(at: i)
                                 }
+                            
+                            if i == 0 {
+                                VStack{
+                                    Spacer()
+                                    Text("대표")
+                                        .font(.napzakFont(.caption3Medium12))
+                                        .applyNapzakTextStyle(napzakFontStyle: .caption3Medium12)
+                                        .frame(maxWidth: .infinity)
+                                        .padding(.vertical, 2)
+                                        .background(Color.napzakTransparency(.black70))
+                                        .foregroundStyle(.white)
+                                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                                }
+                            }
 
                         }
                     }
@@ -92,6 +106,7 @@ struct RegisterImage: View {
 }
 
 #Preview {
+    SellRegisterView()
 //    RegisterImage()
-    TabBarView()
+//    TabBarView()
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -24,7 +24,7 @@ struct RegisterImage: View {
                 .applyNapzakTextStyle(napzakFontStyle: .body6Medium14)
                 .foregroundStyle(Color.napzakGrayScale(.gray600))
             
-            ScrollView(.horizontal) {
+            ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
                     // 사진 선택 버튼
                     PhotosPicker(
@@ -59,6 +59,10 @@ struct RegisterImage: View {
                                 .scaledToFill()
                                 .frame(width: 80, height: 80)
                                 .clipShape(RoundedRectangle(cornerRadius: 12))
+                                .onLongPressGesture {
+                                    let movedImage = images.remove(at: i) // 현재 인덱스의 이미지를 삭제하고 저장
+                                        images.insert(movedImage, at: 0) // 맨 앞으로 삽입
+                                }
                             
                             Image(.icXCircleBlack)
                                 .position(CGPoint(x: 74, y: 6))

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -117,7 +117,3 @@ struct RegisterImage: View {
         
     }
 }
-
-#Preview {
-    TabBarView()
-}

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -28,7 +28,7 @@ struct RegisterImage: View {
                 HStack{
                     PhotosPicker(
                         selection: $photosPickerItem,
-                        maxSelectionCount: 10,
+                        maxSelectionCount: 10-images.count,
                         selectionBehavior: .ordered,
                         matching: .images
                     ) {

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -10,6 +10,7 @@ import PhotosUI
 
 struct RegisterImage: View {
     @State private var images: [UIImage] = []
+    
     @State private var photosPickerItem: [PhotosPickerItem] = []
     
     var body: some View {
@@ -118,7 +119,7 @@ struct RegisterImage: View {
 }
 
 #Preview {
-    SellRegisterView()
-    //    RegisterImage()
+//    SellRegisterView()
+        RegisterImage()
     //    TabBarView()
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import PhotosUI
 
 struct RegisterImage: View {
-    @State private var images: [UIImage] = []
+    @Binding var images: [UIImage]
     
     @State private var photosPickerItem: [PhotosPickerItem] = []
     
@@ -119,7 +119,5 @@ struct RegisterImage: View {
 }
 
 #Preview {
-//    SellRegisterView()
-        RegisterImage()
-    //    TabBarView()
+    TabBarView()
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -61,13 +61,7 @@ struct RegisterImage: View {
                                 .clipShape(RoundedRectangle(cornerRadius: 12))
                                 .onLongPressGesture {
                                     let movedImage = images.remove(at: i) // 현재 인덱스의 이미지를 삭제하고 저장
-                                        images.insert(movedImage, at: 0) // 맨 앞으로 삽입
-                                }
-                            
-                            Image(.icXCircleBlack)
-                                .position(CGPoint(x: 74, y: 6))
-                                .onTapGesture {
-                                    images.remove(at: i)
+                                    images.insert(movedImage, at: 0) // 맨 앞으로 삽입
                                 }
                             
                             if i == 0 {
@@ -80,10 +74,24 @@ struct RegisterImage: View {
                                         .padding(.vertical, 2)
                                         .background(Color.napzakTransparency(.black70))
                                         .foregroundStyle(.white)
-                                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                                        .clipShape(
+                                            .rect(
+                                                bottomLeadingRadius: 12,
+                                                bottomTrailingRadius: 12
+                                            )
+                                        )
                                 }
                             }
-
+                            
+                            Image(.icXCircleBlack)
+                                .frame(width: 24, height: 24)
+                                .position(CGPoint(x: 74, y: 8))
+                                .highPriorityGesture(
+                                    TapGesture().onEnded {
+                                        images.remove(at: i)
+                                    }
+                                )
+                            
                         }
                     }
                 }
@@ -111,6 +119,6 @@ struct RegisterImage: View {
 
 #Preview {
     SellRegisterView()
-//    RegisterImage()
-//    TabBarView()
+    //    RegisterImage()
+    //    TabBarView()
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -84,14 +84,13 @@ struct RegisterImage: View {
                                 }
                             }
                             
-                            Image(.icXCircleBlack)
-                                .frame(width: 24, height: 24)
-                                .position(CGPoint(x: 74, y: 8))
-                                .highPriorityGesture(
-                                    TapGesture().onEnded {
-                                        images.remove(at: i)
-                                    }
-                                )
+                            Button(action: {
+                                images.remove(at: i)
+                            }, label: {
+                                Image(.icXCircleBlack)
+                            })
+                            .frame(width: 24, height: 24)
+                            .position(CGPoint(x: 74, y: 8))
                             
                         }
                     }
@@ -116,4 +115,8 @@ struct RegisterImage: View {
         }
         
     }
+}
+
+#Preview {
+    TabBarView()
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -53,15 +53,23 @@ struct RegisterImage: View {
                     }
                     
                     ForEach(0..<images.count, id: \.self) { i in
-                        Image(uiImage: images[i])
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: 80, height: 80)
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                        ZStack{
+                            Image(uiImage: images[i])
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 80, height: 80)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                            
+                            Image(.icXCircleBlack)
+                                .position(CGPoint(x: 74, y: 6))
+                                .onTapGesture {
+                                    images.remove(at: i)
+                                }
+
+                        }
                     }
                 }
                 .padding(.top, 12)
-
             }
             
         }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/RegisterImage.swift
@@ -6,8 +6,12 @@
 //
 
 import SwiftUI
+import PhotosUI
 
 struct RegisterImage: View {
+    @State private var images: [UIImage] = []
+    @State private var photosPickerItem: [PhotosPickerItem] = []
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("상품 이미지")
@@ -20,24 +24,65 @@ struct RegisterImage: View {
                 .applyNapzakTextStyle(napzakFontStyle: .body6Medium14)
                 .foregroundStyle(Color.napzakGrayScale(.gray600))
             
-            Button {
-                print("버튼 눌림")
-            } label: {
-                VStack(alignment: .center){
-                    Image(.icPhoto)
-                    Text("0/10")
+            ScrollView(.horizontal) {
+                HStack{
+                    PhotosPicker(
+                        selection: $photosPickerItem,
+                        maxSelectionCount: 10,
+                        selectionBehavior: .ordered,
+                        matching: .images
+                    ) {
+                        VStack(alignment: .center){
+                            Image(.icPhoto)
+                            
+                            HStack(spacing: 0) {
+                                Text(images.count.description)
+                                Text("/10")
+                            }
+                            .font(.napzakFont(.caption3Medium12))
+                            .applyNapzakTextStyle(napzakFontStyle: .caption3Medium12)
+                            .foregroundStyle(Color.napzakGrayScale(.gray500))
+                        }
+                        .frame(width: 80, height: 80)
+                        .font(.napzakFont(.caption2SemiBold12))
+                        .applyNapzakTextStyle(napzakFontStyle: .caption2SemiBold12)
+                        .background(Color.napzakGrayScale(.gray100))
+                        .foregroundStyle(Color.napzakGrayScale(.gray500))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .padding(.top, 12)
+                    }
+                    
+                    ForEach(0..<images.count, id: \.self) { i in
+                        Image(uiImage: images[i])
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 80, height: 80)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                        
+                    }
                 }
             }
-            .frame(width: 80, height: 80)
-            .font(.napzakFont(.caption2SemiBold12))
-            .applyNapzakTextStyle(napzakFontStyle: .caption2SemiBold12)
-            .background(Color.napzakGrayScale(.gray100))
-            .foregroundStyle(Color.napzakGrayScale(.gray500))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.top, 12)
+            
         }
         .padding(20)
-        
+        .onChange(of: photosPickerItem) { _ in
+            Task {
+                for item in photosPickerItem {
+                    if let data = try? await item.loadTransferable(type: Data.self) {
+                        if let image = UIImage(data: data) {
+                            images.append(image)
+                        }
+                    }
+                }
+                
+                photosPickerItem.removeAll()
+            }
+        }
         
     }
+}
+
+#Preview {
+//    RegisterImage()
+    TabBarView()
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/Sell/RegisterDeliveryCharge.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/Sell/RegisterDeliveryCharge.swift
@@ -48,8 +48,8 @@ struct RegisterDeliveryCharge: View {
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                         .foregroundStyle(
                             deliveryChargeFree ? Color
-                                .napzakGrayScale(.gray900) : Color
-                                .napzakGrayScale(.gray600)
+                                .napzakGrayScale(.gray600) : Color
+                                .napzakGrayScale(.gray900)
                         )
                 }
                 

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/Sell/RegisterSellHeader.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Components/Sell/RegisterSellHeader.swift
@@ -11,25 +11,32 @@ struct RegisterSellHeader: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        HStack{
-            Button {
-                dismiss()
-            } label: {
-                Image(systemName: "multiply")
-            }
-            .frame(width: 24, height: 24)
-            .foregroundStyle(Color.napzakGrayScale(.gray900))
-
-            Spacer()
-            Text("팔아요 등록")
-                .font(.napzakFont(.title5SemiBold18))
-                .applyNapzakTextStyle(napzakFontStyle: .title5SemiBold18)
+        ZStack{
+            HStack{
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .frame(width: 24, height: 24)
                 .foregroundStyle(Color.napzakGrayScale(.gray900))
+                
+                Spacer()
+            }
+            .padding(.leading, 20)
             
-            Spacer()
+            HStack{
+                Spacer()
+                
+                Text("팔아요 등록")
+                    .font(.napzakFont(.title5SemiBold18))
+                    .applyNapzakTextStyle(napzakFontStyle: .title5SemiBold18)
+                    .foregroundStyle(Color.napzakGrayScale(.gray900))
+                
+                Spacer()
+            }
+            .padding(.vertical, 10)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 5)
         
         Divider()
     }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Model/RegisterModel.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/Model/RegisterModel.swift
@@ -1,0 +1,25 @@
+//
+//  RegisterModel.swift
+//  Napzakmarket-iOS
+//
+//  Created by OneTen on 1/16/25.
+//
+
+import SwiftUI
+
+final class RegisterModel: ObservableObject {
+    @State var filledRegisterInfo: Bool = false     // 변수명 뭔가뭔가임... 흠
+    
+    
+    // MARK: - 버튼 활성화 로직
+    
+    
+    
+    // MARK: - 등록정보 REQUEST POST 로직
+    
+    
+    // MARK: - 장르 검색 RESPONSE GET 로직
+    
+    
+    
+}

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/View/BuyRegisterView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/View/BuyRegisterView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct BuyRegisterView: View {
+    @State private var images: [UIImage] = []
     @State private var title = ""
     @State private var description = ""
     @State private var genre = ""
@@ -19,7 +20,8 @@ struct BuyRegisterView: View {
             VStack(alignment: .leading) {
                 
                 // 상품 이미지
-                RegisterImage()
+                RegisterImage(images: $images)
+
                 
                 // 장르
                 RegisterGenre(genre: $genre)

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/View/RegisterView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/View/RegisterView.swift
@@ -37,7 +37,7 @@ struct RegisterView: View {
             .background(Color.napzakGrayScale(.gray400))
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .padding(.horizontal, 20)
-            .padding(.vertical, 1)
+            .padding(.vertical, 35)
         }
         .scrollIndicators(.hidden)
     }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/View/RegisterView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/View/RegisterView.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct RegisterView: View {
-    // 뷰 불러올 때 Sell 이냐 Buy냐로 구분해서 보여주면 될 듯 나중에 탭바에서 Boolean값으로 바인딩 받아오기
     @Binding var registerType: Bool
+    
+    @StateObject private var registerModel = RegisterModel()
     
     var body: some View {
         NavigationStack {
@@ -34,7 +35,11 @@ struct RegisterView: View {
                     .foregroundStyle(.white)
                     .frame(maxWidth: .infinity, minHeight: 52)
             })
-            .background(Color.napzakGrayScale(.gray400))
+            .background(
+                registerModel.filledRegisterInfo
+                ? Color.napzakPurple(.purple30)
+                : Color.napzakGrayScale(.gray400)
+            )
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .padding(.horizontal, 20)
             .padding(.vertical, 35)

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/View/SellRegisterView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/View/SellRegisterView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SellRegisterView: View {
+    @State private var images: [UIImage] = []
     @State private var title = ""
     @State private var description = ""
     @State private var genre = ""
@@ -24,7 +25,7 @@ struct SellRegisterView: View {
             VStack(alignment: .leading) {
                 
                 // 상품 이미지
-                RegisterImage()
+                RegisterImage(images: $images)
                 
                 // 장르
                 RegisterGenre(genre: $genre)
@@ -61,4 +62,8 @@ struct SellRegisterView: View {
         }
     }
 
+}
+
+#Preview {
+    TabBarView()
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/View/SellRegisterView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Register/View/SellRegisterView.swift
@@ -60,10 +60,7 @@ struct SellRegisterView: View {
             }
             .padding(.bottom, 67)
         }
+        
     }
 
-}
-
-#Preview {
-    TabBarView()
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Tabbar/View/TabBarView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Tabbar/View/TabBarView.swift
@@ -124,9 +124,7 @@ struct TabBarView: View {
     }
     
     private func registerButton(type: String, icon: String) -> some View {
-        Button(action: {
-            print("\(type) 등록 클릭")
-            
+        Button(action: {            
             if type == "팔아요" {
                 registerType = true
             } else {


### PR DESCRIPTION
## 🌴 작업한 브랜치
- feat/#27에서 작업했습니다


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- [x] 갤러리 열어서 이미지 불러오기
- [x] 사이즈 맞춰서 나열하기
- [x] 이미지 우측 상단에 x 삭제 버튼
- [x] 대표 사진 기능
- [x] 디쌤들 피드백 반영

```
PhotosPicker(
                        selection: $photosPickerItem,
                        maxSelectionCount: 10-images.count,
                        selectionBehavior: .ordered,
                        matching: .images
                    )
```
총 사진 선택 가능 개수 10개라서 `maxSelectionCount: 10-images.count` 이렇게 해줬습니다.

`selectionBehavior`는 사진 선택시 체크 표시가 보일 건지 숫자표시가 보일건지 고르는 프로퍼티로, 
아요는 사진 선택한 순서대로 업로드되기에 디쌤들과 상의 끝에 숫자 표시마크가 보이게 구현했습니다.

`matching`는 선택 가능한 요소의 종류를 제한하는 기능으로(스크린샷만, 동영상만, 사진만, 라이브포토만 이런식으로 선택가능),
사진들만 선택할 수 있게 만들었습니다. 

## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/d486e290-1e2e-43a2-9bd6-e97647122c72" width ="250">|


## 📟 관련 이슈
- Resolved: #27
