### PR TITLE
[Network] #61 - 탐색 탭 상품 조회 API 연결

### DIFF
--- a/Napzakmarket-iOS/Napzakmarket-iOS.xcodeproj/project.pbxproj
+++ b/Napzakmarket-iOS/Napzakmarket-iOS.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		6CA556E42D38E11700AD1CF6 /* RegisterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA556E32D38E11700AD1CF6 /* RegisterModel.swift */; };
 		D00CF6532D3E797F00F48230 /* MarketModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00CF64E2D3E797E00F48230 /* MarketModel.swift */; };
 		D00CF6542D3E797F00F48230 /* MarketView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00CF6502D3E797E00F48230 /* MarketView.swift */; };
+		D01CBA832D414E7C00F6FE51 /* ProductSearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01CBA812D414E7C00F6FE51 /* ProductSearchModel.swift */; };
 		D0283BA62D3D6D07002F302A /* SearchInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0283BA52D3D6CF8002F302A /* SearchInputView.swift */; };
 		D02CAB5C2D34A9CC00B0D93F /* ProductItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02CAB5B2D34A9C200B0D93F /* ProductItemView.swift */; };
 		D02CAB612D34EBAB00B0D93F /* NZSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02CAB602D34EB9C00B0D93F /* NZSegmentedControl.swift */; };
@@ -87,7 +88,6 @@
 		D0AA21362D2CFF9F004CC2E6 /* FontLiterial.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0AA21352D2CFF99004CC2E6 /* FontLiterial.swift */; };
 		D0C26EB72D3797A10014EB4C /* SortModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C26EB62D3797980014EB4C /* SortModalView.swift */; };
 		D61342532D3A92B800E65EFD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D61342522D3A92B800E65EFD /* Assets.xcassets */; };
-		D61342762D40345300E65EFD /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61342752D40345300E65EFD /* Encodable+.swift */; };
 		D61342782D40C90600E65EFD /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61342772D40C90600E65EFD /* HomeModel.swift */; };
 		D63F2FCC2D369B9C00C1C7D1 /* AppEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63F2FCB2D369B9C00C1C7D1 /* AppEntryView.swift */; };
 		D63F2FCF2D38D6A300C1C7D1 /* splash(ios).json in Resources */ = {isa = PBXBuildFile; fileRef = D63F2FCE2D38D6A300C1C7D1 /* splash(ios).json */; };
@@ -140,6 +140,7 @@
 		6CA556E32D38E11700AD1CF6 /* RegisterModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterModel.swift; sourceTree = "<group>"; };
 		D00CF64E2D3E797E00F48230 /* MarketModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketModel.swift; sourceTree = "<group>"; };
 		D00CF6502D3E797E00F48230 /* MarketView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketView.swift; sourceTree = "<group>"; };
+		D01CBA812D414E7C00F6FE51 /* ProductSearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchModel.swift; sourceTree = "<group>"; };
 		D0283BA52D3D6CF8002F302A /* SearchInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInputView.swift; sourceTree = "<group>"; };
 		D02CAB5B2D34A9C200B0D93F /* ProductItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductItemView.swift; sourceTree = "<group>"; };
 		D02CAB602D34EB9C00B0D93F /* NZSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NZSegmentedControl.swift; sourceTree = "<group>"; };
@@ -367,6 +368,14 @@
 				D00CF6512D3E797E00F48230 /* View */,
 			);
 			path = Market;
+			sourceTree = "<group>";
+		};
+		D01CBA822D414E7C00F6FE51 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				D01CBA812D414E7C00F6FE51 /* ProductSearchModel.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		D02CAB5F2D34EB9300B0D93F /* SegmentedControl */ = {
@@ -714,6 +723,7 @@
 		D0AA210B2D2C0C34004CC2E6 /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				D01CBA822D414E7C00F6FE51 /* Model */,
 				D0AA210C2D2C0C3E004CC2E6 /* View */,
 			);
 			path = Search;
@@ -1073,6 +1083,7 @@
 				D0AA20EE2D2C0A56004CC2E6 /* Napzakmarket_iOSApp.swift in Sources */,
 				D07972692D3F74D000CF97E4 /* GenreAPI.swift in Sources */,
 				6C2D5B6C2D32B7E300E904C6 /* RegisterDescription.swift in Sources */,
+				D01CBA832D414E7C00F6FE51 /* ProductSearchModel.swift in Sources */,
 				D0AA21362D2CFF9F004CC2E6 /* FontLiterial.swift in Sources */,
 				D0C26EB72D3797A10014EB4C /* SortModalView.swift in Sources */,
 				6C2D5B682D32B51200E904C6 /* RegisterGenre.swift in Sources */,

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Global/Components/ProductItem/ProductModel.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Global/Components/ProductItem/ProductModel.swift
@@ -52,7 +52,7 @@ final class ProductModel: Identifiable, ObservableObject {
         self.id = dto.productId
         self.genreName = dto.genreName
         self.productName = dto.productName
-        self.photo = dto.photo
+        self.photo = dto.photo ?? ""
         self.price = dto.price
         self.uploadTime = dto.uploadTime
         self.isInterested = dto.isInterested

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Global/Resources/Assets.xcassets/Component/icn_heart_list.imageset/Contents.json
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Global/Resources/Assets.xcassets/Component/icn_heart_list.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "icn_heart_list.svg",
+      "filename" : "ic_heart_list.svg",
       "idiom" : "universal"
     }
   ],

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Global/Resources/Assets.xcassets/Component/icn_heart_list.imageset/ic_heart_list.svg
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Global/Resources/Assets.xcassets/Component/icn_heart_list.imageset/ic_heart_list.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 7.69431C10 2.99988 3 3.49988 3 9.49991C3 15.4999 12 20.5001 12 20.5001C12 20.5001 21 15.4999 21 9.49991C21 3.49988 14 2.99988 12 7.69431Z" fill="black" fill-opacity="0.17" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Global/Resources/Assets.xcassets/Component/icn_heart_list.imageset/icn_heart_list.svg
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Global/Resources/Assets.xcassets/Component/icn_heart_list.imageset/icn_heart_list.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 7.69431C10 2.99988 3 3.49988 3 9.49991C3 15.4999 12 20.5001 12 20.5001C12 20.5001 21 15.4999 21 9.49991C21 3.49988 14 2.99988 12 7.69431Z" fill="white" fill-opacity="0.2" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/DTO/Response/ProductResponseDTO.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/DTO/Response/ProductResponseDTO.swift
@@ -68,7 +68,7 @@ struct Product: Codable {
     let productId: Int
     let genreName: String
     let productName: String
-    let photo: String
+    let photo: String?
     let price: Int
     let uploadTime: String
     let isInterested: Bool

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/DTO/Response/ProductResponseDTO.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/DTO/Response/ProductResponseDTO.swift
@@ -40,11 +40,11 @@ struct RecommandedBuyProductData: Codable {
 struct SellProductResponseDTO: Codable {
     let status: Int
     let message: String
-    let data: PopularSellProductData
+    let data: SellProductData
 }
 
 struct SellProductData: Codable {
-    let productSellList: [SellProduct]
+    let productSellList: [Product]
     var nextCursor: String?
 }
 
@@ -55,7 +55,7 @@ struct BuyProductResponseDTO: Codable {
 }
 
 struct BuyProductData: Codable {
-    let productBuyList: [BuyProduct]
+    let productBuyList: [Product]
     var nextCursor: String?
 }
 
@@ -76,31 +76,4 @@ struct Product: Codable {
     let tradeStatus: String
     let isOwnedByCurrentUser: Bool
     let isPriceNegotiable: Bool?
-}
-
-struct BuyProduct: Codable {
-    let productId: Int
-    let genreName: String
-    let productName: String
-    let photo: String
-    let price: Int
-    let uploadTime: String
-    let isInterested: Bool
-    let tradeType: String
-    let tradeStatus: String
-    let isPriceNegotiable: Bool
-    let isOwnedByCurrentUser: Bool
-}
-
-struct SellProduct: Codable {
-    let productId: Int
-    let genreName: String
-    let productName: String
-    let photo: String
-    let price: Int
-    let uploadTime: String
-    let isInterested: Bool
-    let tradeType: String
-    let tradeStatus: String
-    let isOwnedByCurrentUser: Bool
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/ProductAPI.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/ProductAPI.swift
@@ -67,7 +67,7 @@ extension ProductAPI: BaseTargetType {
         case .getSellProductForSearch:
             return "products/sell/search"
         case .getBuyProductForSearch:
-            return "products/sell/buy"
+            return "products/buy/search"
         }
     }
     

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/ProductAPI.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/ProductAPI.swift
@@ -15,6 +15,8 @@ enum ProductAPI {
     case getPopularSellProducts
     case getRecommandedBuyProducts
     case putPresignedURL(url: String, imageData: Data)
+    case getSellProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool, isUnopened: Bool)
+    case getBuyProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool)
 }
 
 extension ProductAPI: BaseTargetType {
@@ -40,7 +42,7 @@ extension ProductAPI: BaseTargetType {
         case .putPresignedURL:
             return .noneHeader
             
-        case .getBanners, .getPersonalProducts, .getPopularSellProducts, .getRecommandedBuyProducts:
+        case .getBanners, .getPersonalProducts, .getPopularSellProducts, .getRecommandedBuyProducts, .getSellProduct, .getBuyProduct:
             return .accessTokenHeader
         }
     }
@@ -57,12 +59,16 @@ extension ProductAPI: BaseTargetType {
             return "products/home/buy"
         case .putPresignedURL:
             return ""
+        case .getSellProduct:
+            return "products/sell"
+        case .getBuyProduct:
+            return "products/buy"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getBanners, .getPersonalProducts, .getPopularSellProducts, .getRecommandedBuyProducts:
+        case .getBanners, .getPersonalProducts, .getPopularSellProducts, .getRecommandedBuyProducts, .getSellProduct, .getBuyProduct:
             return .get
         case .putPresignedURL:
             return .put
@@ -75,7 +81,17 @@ extension ProductAPI: BaseTargetType {
             return .requestPlain
         case .putPresignedURL(_, let imageData):
             return .requestData(imageData)
+        case .getSellProduct(let sortOption, let genreIDs, let isOnSale, let isUnopened):
+            return .requestParameters(parameters: ["sortOption" : sortOption,
+                                                   "genreId" : genreIDs ?? [],
+                                                   "isOnSale" : isOnSale,
+                                                   "isUnopened" : isUnopened],
+                                      encoding: URLEncoding.queryString)
+        case .getBuyProduct(let sortOption, let genreIDs, let isOnSale):
+            return .requestParameters(parameters: ["sortOption" : sortOption,
+                                                   "genreId" : genreIDs ?? [],
+                                                   "isOnSale" : isOnSale],
+                                      encoding: URLEncoding.queryString)
         }
     }
-    
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/ProductAPI.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/ProductAPI.swift
@@ -17,6 +17,8 @@ enum ProductAPI {
     case putPresignedURL(url: String, imageData: Data)
     case getSellProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool, isUnopened: Bool)
     case getBuyProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool)
+    case getSellProductForSearch(searchWord: String, sortOption: String, genreIDs: [Int]?, isOnSale: Bool, isUnopened: Bool)
+    case getBuyProductForSearch(searchWord: String, sortOption: String, genreIDs: [Int]?, isOnSale: Bool)
 }
 
 extension ProductAPI: BaseTargetType {
@@ -41,8 +43,7 @@ extension ProductAPI: BaseTargetType {
         switch self {
         case .putPresignedURL:
             return .noneHeader
-            
-        case .getBanners, .getPersonalProducts, .getPopularSellProducts, .getRecommandedBuyProducts, .getSellProduct, .getBuyProduct:
+        default:
             return .accessTokenHeader
         }
     }
@@ -63,15 +64,19 @@ extension ProductAPI: BaseTargetType {
             return "products/sell"
         case .getBuyProduct:
             return "products/buy"
+        case .getSellProductForSearch:
+            return "products/sell/search"
+        case .getBuyProductForSearch:
+            return "products/sell/buy"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getBanners, .getPersonalProducts, .getPopularSellProducts, .getRecommandedBuyProducts, .getSellProduct, .getBuyProduct:
-            return .get
         case .putPresignedURL:
             return .put
+        default:
+            return .get
         }
     }
     
@@ -89,6 +94,19 @@ extension ProductAPI: BaseTargetType {
                                       encoding: URLEncoding.queryString)
         case .getBuyProduct(let sortOption, let genreIDs, let isOnSale):
             return .requestParameters(parameters: ["sortOption" : sortOption,
+                                                   "genreId" : genreIDs ?? [],
+                                                   "isOnSale" : isOnSale],
+                                      encoding: URLEncoding.queryString)
+        case .getSellProductForSearch(let searchWord, let sortOption, let genreIDs, let isOnSale, let isUnopened):
+            return .requestParameters(parameters: ["searchWord" : searchWord,
+                                                   "sortOption" : sortOption,
+                                                   "genreId" : genreIDs ?? [],
+                                                   "isOnSale" : isOnSale,
+                                                   "isUnopened" : isUnopened],
+                                      encoding: URLEncoding.queryString)
+        case .getBuyProductForSearch(let searchWord, let sortOption, let genreIDs, let isOnSale):
+            return .requestParameters(parameters: ["searchWord" : searchWord,
+                                                   "sortOption" : sortOption,
                                                    "genreId" : genreIDs ?? [],
                                                    "isOnSale" : isOnSale],
                                       encoding: URLEncoding.queryString)

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/ProductService.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/ProductService.swift
@@ -21,6 +21,8 @@ protocol ProductServiceProtocol {
     )
     func getSellProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool, isUnopened: Bool, completion: @escaping (NetworkResult<SellProductResponseDTO>) -> ())
     func getBuyProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool, completion: @escaping (NetworkResult<BuyProductResponseDTO>) -> ())
+    func getSellProductForSearch(searchWord: String, sortOption: String, genreIDs: [Int]?, isOnSale: Bool, isUnopened: Bool, completion: @escaping (NetworkResult<SellProductResponseDTO>) -> ())
+    func getBuyProductForSearch(searchWord: String, sortOption: String, genreIDs: [Int]?, isOnSale: Bool, completion: @escaping (NetworkResult<BuyProductResponseDTO>) -> ())
 }
 
 final class ProductService: BaseService, ProductServiceProtocol {
@@ -50,6 +52,15 @@ final class ProductService: BaseService, ProductServiceProtocol {
     func getBuyProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool, completion: @escaping (NetworkResult<BuyProductResponseDTO>) -> ()) {
         request(.getBuyProduct(sortOption: sortOption, genreIDs: genreIDs, isOnSale: isOnSale), completion: completion)
     }
+    
+    func getSellProductForSearch(searchWord: String, sortOption: String, genreIDs: [Int]?, isOnSale: Bool, isUnopened: Bool, completion: @escaping (NetworkResult<SellProductResponseDTO>) -> ()) {
+        request(.getSellProductForSearch(searchWord: searchWord, sortOption: sortOption, genreIDs: genreIDs, isOnSale: isOnSale, isUnopened: isUnopened), completion: completion)
+    }
+    
+    func getBuyProductForSearch(searchWord: String, sortOption: String, genreIDs: [Int]?, isOnSale: Bool, completion: @escaping (NetworkResult<BuyProductResponseDTO>) -> ()) {
+        request(.getBuyProductForSearch(searchWord: searchWord, sortOption: sortOption, genreIDs: genreIDs, isOnSale: isOnSale), completion: completion)
+    }
+
     
     private func request<T: Decodable>(_ target: ProductAPI, completion: @escaping (NetworkResult<T>) -> ()) {
         provider.request(target) { [weak self] result in

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/ProductService.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Network/Product/ProductService.swift
@@ -19,6 +19,8 @@ protocol ProductServiceProtocol {
         imageData: Data,
         completion: @escaping (NetworkResult<Void>) -> ()
     )
+    func getSellProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool, isUnopened: Bool, completion: @escaping (NetworkResult<SellProductResponseDTO>) -> ())
+    func getBuyProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool, completion: @escaping (NetworkResult<BuyProductResponseDTO>) -> ())
 }
 
 final class ProductService: BaseService, ProductServiceProtocol {
@@ -39,6 +41,14 @@ final class ProductService: BaseService, ProductServiceProtocol {
     
     func getRecommandedBuyProducts(completion: @escaping (NetworkResult<RecommandedBuyProductResponseDTO>) -> ()) {
         request(.getRecommandedBuyProducts, completion: completion)
+    }
+    
+    func getSellProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool, isUnopened: Bool, completion: @escaping (NetworkResult<SellProductResponseDTO>) -> ()) {
+        request(.getSellProduct(sortOption: sortOption, genreIDs: genreIDs, isOnSale: isOnSale, isUnopened: isUnopened), completion: completion)
+    }
+    
+    func getBuyProduct(sortOption: String, genreIDs: [Int]?, isOnSale: Bool, completion: @escaping (NetworkResult<BuyProductResponseDTO>) -> ()) {
+        request(.getBuyProduct(sortOption: sortOption, genreIDs: genreIDs, isOnSale: isOnSale), completion: completion)
     }
     
     private func request<T: Decodable>(_ target: ProductAPI, completion: @escaping (NetworkResult<T>) -> ()) {

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Market/View/MarketView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Market/View/MarketView.swift
@@ -15,7 +15,7 @@ struct MarketView: View {
     @State private var selectedIndex = 0
     @State private var sellProducts = ProductModel.dummyProducts
     @State private var buyProducts = ProductModel.dummyProducts
-    @State private var selectedSortOption: SortOption = .latest
+    @State private var selectedSortOption: SortOption = .recent
     @State private var selectedGenres: [GenreName] = []
     @State private var selectedGenreStrings: [String] = []
     @State private var sortModalViewIsPresented = false
@@ -103,7 +103,7 @@ struct MarketView: View {
                             }
                             .padding(.horizontal, 20)
                             .onChange(of: selectedIndex) { _ in
-                                selectedSortOption = .latest
+                                selectedSortOption = .recent
                                 proxy.scrollTo("header", anchor: .top)
                             }
                         }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/Model/ProductSearchModel.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/Model/ProductSearchModel.swift
@@ -1,0 +1,53 @@
+//
+//  ProductSearchModel.swift
+//  Napzakmarket-iOS
+//
+//  Created by 조혜린 on 1/16/25.
+//
+
+import Foundation
+
+struct ProductFetchOption: Equatable {
+    var sortOption: SortOption
+    var genreIDs: [Int]
+    var isOnSale: Bool
+    var isUnopened: Bool
+}
+
+final class ProductSearchModel: ObservableObject {
+
+    //MARK: - Property Wrappers
+
+    @Published var sellProducts: [ProductModel] = []
+    @Published var buyProducts: [ProductModel] = []
+}
+
+extension ProductSearchModel {
+
+    //MARK: - API Request Func
+
+    func getSellProducts(productFetchOption: ProductFetchOption) async {
+        NetworkService.shared.productService.getSellProduct(sortOption: productFetchOption.sortOption.rawValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale, isUnopened: productFetchOption.isUnopened) { [weak self] result in
+            switch result {
+            case .success(let response):
+                guard let response else { return }
+                self?.sellProducts = response.data.productSellList.map { ProductModel(dto: $0) }
+            default:
+                break
+            }
+        }
+    }
+
+    func getBuyProducts(productFetchOption: ProductFetchOption) async {
+        NetworkService.shared.productService.getBuyProduct(sortOption: productFetchOption.sortOption.rawValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale) { [weak self] result in
+            switch result {
+            case .success(let response):
+                guard let response else { return }
+                self?.buyProducts = response.data.productBuyList.map { ProductModel(dto: $0) }
+            default:
+                break
+            }
+        }
+    }
+
+}

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/Model/ProductSearchModel.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/Model/ProductSearchModel.swift
@@ -12,6 +12,10 @@ struct ProductFetchOption: Equatable {
     var genreIDs: [Int]
     var isOnSale: Bool
     var isUnopened: Bool
+    
+    var sortOptionValue: String {
+        return sortOption.rawValue
+    }
 }
 
 final class ProductSearchModel: ObservableObject {
@@ -27,7 +31,7 @@ extension ProductSearchModel {
     //MARK: - API Request Func
 
     func getSellProducts(productFetchOption: ProductFetchOption) async {
-        NetworkService.shared.productService.getSellProduct(sortOption: productFetchOption.sortOption.rawValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale, isUnopened: productFetchOption.isUnopened) { [weak self] result in
+        NetworkService.shared.productService.getSellProduct(sortOption: productFetchOption.sortOptionValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale, isUnopened: productFetchOption.isUnopened) { [weak self] result in
             switch result {
             case .success(let response):
                 guard let response else { return }
@@ -39,7 +43,7 @@ extension ProductSearchModel {
     }
 
     func getBuyProducts(productFetchOption: ProductFetchOption) async {
-        NetworkService.shared.productService.getBuyProduct(sortOption: productFetchOption.sortOption.rawValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale) { [weak self] result in
+        NetworkService.shared.productService.getBuyProduct(sortOption: productFetchOption.sortOptionValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale) { [weak self] result in
             switch result {
             case .success(let response):
                 guard let response else { return }
@@ -51,7 +55,7 @@ extension ProductSearchModel {
     }
 
     func getSellProductsForSearch(searchWord: String, productFetchOption: ProductFetchOption) async {
-        NetworkService.shared.productService.getSellProductForSearch(searchWord: searchWord, sortOption: productFetchOption.sortOption.rawValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale, isUnopened: productFetchOption.isUnopened) { [weak self] result in
+        NetworkService.shared.productService.getSellProductForSearch(searchWord: searchWord, sortOption: productFetchOption.sortOptionValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale, isUnopened: productFetchOption.isUnopened) { [weak self] result in
             switch result {
             case .success(let response):
                 guard let response else { return }
@@ -63,7 +67,7 @@ extension ProductSearchModel {
     }
 
     func getBuyProductsForSearch(searchWord: String, productFetchOption: ProductFetchOption) async {
-        NetworkService.shared.productService.getBuyProductForSearch(searchWord: searchWord, sortOption: productFetchOption.sortOption.rawValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale) { [weak self] result in
+        NetworkService.shared.productService.getBuyProductForSearch(searchWord: searchWord, sortOption: productFetchOption.sortOptionValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale) { [weak self] result in
             switch result {
             case .success(let response):
                 guard let response else { return }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/Model/ProductSearchModel.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/Model/ProductSearchModel.swift
@@ -50,4 +50,28 @@ extension ProductSearchModel {
         }
     }
 
+    func getSellProductsForSearch(searchWord: String, productFetchOption: ProductFetchOption) async {
+        NetworkService.shared.productService.getSellProductForSearch(searchWord: searchWord, sortOption: productFetchOption.sortOption.rawValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale, isUnopened: productFetchOption.isUnopened) { [weak self] result in
+            switch result {
+            case .success(let response):
+                guard let response else { return }
+                self?.sellProducts = response.data.productSellList.map { ProductModel(dto: $0) }
+            default:
+                break
+            }
+        }
+    }
+
+    func getBuyProductsForSearch(searchWord: String, productFetchOption: ProductFetchOption) async {
+        NetworkService.shared.productService.getBuyProductForSearch(searchWord: searchWord, sortOption: productFetchOption.sortOption.rawValue, genreIDs: productFetchOption.genreIDs, isOnSale: productFetchOption.isOnSale) { [weak self] result in
+            switch result {
+            case .success(let response):
+                guard let response else { return }
+                self?.buyProducts = response.data.productBuyList.map { ProductModel(dto: $0) }
+            default:
+                break
+            }
+        }
+    }
+
 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/Modal/GenreFilterModalView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/Modal/GenreFilterModalView.swift
@@ -137,24 +137,21 @@ extension GenreFilterModalView {
     
     private var genreScrollView: some View {
         ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 10) {
+            LazyVGrid(columns: [GridItem(.flexible())], alignment: .leading, spacing: 0) {
                 ForEach(genreList, id: \.self) { genre in
-                    HStack {
+                    HStack(alignment: .center) {
                         Text("\(genre.genreName)")
                             .font(.napzakFont(.body5SemiBold14))
                             .applyNapzakTextStyle(napzakFontStyle: .body5SemiBold14)
                             .foregroundStyle(Color.napzakGrayScale(.gray800))
-                        Spacer()
                     }
                     .frame(height: 60)
-                    .contentShape(Rectangle())
                     .onTapGesture {
                         isSearchBarFocused = false
                         if !selectedGenres.contains(genre) && selectedGenres.count < 4 {
                             selectedGenres.append(genre)
                         }
                     }
-                    
                     if genre != genreList.last {
                         Divider()
                             .frame(height: 1)

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/Modal/SortModalView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/Modal/SortModalView.swift
@@ -7,13 +7,6 @@
 
 import SwiftUI
 
-enum SortOption: String {
-    case latest = "최신순"
-    case popular = "인기순"
-    case highPrice = "고가순"
-    case lowPrice = "저가순"
-}
-
 struct SortModalView: View {
     
     //MARK: - Property Wrappers
@@ -26,7 +19,7 @@ struct SortModalView: View {
     //MARK: - Properties
     
     private let modalHeight: CGFloat = 302
-    private let sortOptions: [SortOption] = [.latest, .popular, .highPrice, .lowPrice]
+    private let sortOptions: [SortOption] = [.recent, .popular, .highPrice, .lowPrice]
     
     //MARK: - Main Body
     
@@ -80,7 +73,7 @@ extension SortModalView {
                 VStack(spacing: 0) {
                     Spacer()
                     HStack {
-                        Text("\(option.rawValue)")
+                        Text("\(option.title)")
                             .font(.napzakFont(.title5SemiBold18))
                             .applyNapzakTextStyle(napzakFontStyle: .title5SemiBold18)
                             .foregroundStyle(option == selectedSortOption ? Color.napzakPurple(.purple30) : Color.napzakGrayScale(.gray900))

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchInputView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchInputView.swift
@@ -62,7 +62,16 @@ struct SearchInputView: View {
         }
         .navigationDestination(isPresented: $isGenreSelected) {
             if let adaptedGenre {
-                SearchView(adaptedGenres: [adaptedGenre], isBackButtonHidden: false)
+                SearchView(
+                    adaptedGenres: [adaptedGenre],
+                    productFetchOption: ProductFetchOption(
+                        sortOption: .recent,
+                        genreIDs: [adaptedGenre.id],
+                        isOnSale: false,
+                        isUnopened: false
+                    ),
+                    isBackButtonHidden: false
+                )
             }
         }
     }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
@@ -125,8 +125,13 @@ struct SearchView: View {
             }
             .onAppear() {
                 Task {
-                    await productModel.getSellProducts(productFetchOption: productFetchOption)
-                    await productModel.getBuyProducts(productFetchOption: productFetchOption)
+                    if searchResultText.isEmpty {
+                        await productModel.getSellProducts(productFetchOption: productFetchOption)
+                        await productModel.getBuyProducts(productFetchOption: productFetchOption)
+                    } else {
+                        await productModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                        await productModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                    }
                 }
             }
             .onChange(of: adaptedGenres) { _ in

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
@@ -310,27 +310,48 @@ extension SearchView {
                 productFetchOption.sortOption = .recent
                 proxy.scrollTo("header", anchor: .top)
                 Task {
-                    if isFiltered {
-                        await productModel.getBuyProducts(productFetchOption: productFetchOption)
-                        await productModel.getSellProducts(productFetchOption: productFetchOption)
-                    } else {
-                        if selectedTabIndex == 0 {
+                    if searchResultText.isEmpty {
+                        if isFiltered {
                             await productModel.getBuyProducts(productFetchOption: productFetchOption)
-                        } else if selectedTabIndex == 1 {
                             await productModel.getSellProducts(productFetchOption: productFetchOption)
+                        } else {
+                            if selectedTabIndex == 0 {
+                                await productModel.getBuyProducts(productFetchOption: productFetchOption)
+                            } else if selectedTabIndex == 1 {
+                                await productModel.getSellProducts(productFetchOption: productFetchOption)
+                            }
+                        }
+                    } else {
+                        if isFiltered {
+                            await productModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                            await productModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                        } else {
+                            if selectedTabIndex == 0 {
+                                await productModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                            } else if selectedTabIndex == 1 {
+                                await productModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                            }
                         }
                     }
+                    isFiltered = false
                 }
             }
             .onChange(of: productFetchOption) { _ in
                 proxy.scrollTo("header", anchor: .top)
-                isFiltered = productFetchOption.sortOption != .recent || productFetchOption.isOnSale || productFetchOption.isUnopened || !productFetchOption.genreIDs.isEmpty
-                
+                isFiltered = true
                 Task {
-                    if selectedTabIndex == 0 {
-                        await productModel.getSellProducts(productFetchOption: productFetchOption)
-                    } else if selectedTabIndex == 1 {
-                        await productModel.getBuyProducts(productFetchOption: productFetchOption)
+                    if searchResultText.isEmpty {
+                        if selectedTabIndex == 0 {
+                            await productModel.getSellProducts(productFetchOption: productFetchOption)
+                        } else if selectedTabIndex == 1 {
+                            await productModel.getBuyProducts(productFetchOption: productFetchOption)
+                        }
+                    } else {
+                        if selectedTabIndex == 0 {
+                            await productModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                        } else if selectedTabIndex == 1 {
+                            await productModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                        }
                     }
                 }
             }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
@@ -46,6 +46,7 @@ struct SearchView: View {
     
     //상품 분류
     @State var productFetchOption = ProductFetchOption(sortOption: .recent, genreIDs: [], isOnSale: false, isUnopened: false)
+    @State var isFiltered = false
     
     //화면 전환
     @State var sortModalViewIsPresented = false
@@ -309,15 +310,22 @@ extension SearchView {
                 productFetchOption.sortOption = .recent
                 proxy.scrollTo("header", anchor: .top)
                 Task {
-                    if selectedTabIndex == 0 {
+                    if isFiltered {
                         await productModel.getBuyProducts(productFetchOption: productFetchOption)
-                    } else if selectedTabIndex == 1 {
                         await productModel.getSellProducts(productFetchOption: productFetchOption)
+                    } else {
+                        if selectedTabIndex == 0 {
+                            await productModel.getBuyProducts(productFetchOption: productFetchOption)
+                        } else if selectedTabIndex == 1 {
+                            await productModel.getSellProducts(productFetchOption: productFetchOption)
+                        }
                     }
                 }
             }
             .onChange(of: productFetchOption) { _ in
                 proxy.scrollTo("header", anchor: .top)
+                isFiltered = productFetchOption.sortOption != .recent || productFetchOption.isOnSale || productFetchOption.isUnopened || !productFetchOption.genreIDs.isEmpty
+                
                 Task {
                     if selectedTabIndex == 0 {
                         await productModel.getSellProducts(productFetchOption: productFetchOption)

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
@@ -35,7 +35,7 @@ struct SearchView: View {
     @EnvironmentObject private var tabBarState: TabBarStateModel
     
     //상품 모델
-    @StateObject private var productModel = ProductSearchModel()
+    @StateObject private var productSearchModel = ProductSearchModel()
     
     //세그먼트 컨트롤
     @State var selectedTabIndex = 0
@@ -127,11 +127,11 @@ struct SearchView: View {
             .onAppear() {
                 Task {
                     if searchResultText.isEmpty {
-                        await productModel.getSellProducts(productFetchOption: productFetchOption)
-                        await productModel.getBuyProducts(productFetchOption: productFetchOption)
+                        await productSearchModel.getSellProducts(productFetchOption: productFetchOption)
+                        await productSearchModel.getBuyProducts(productFetchOption: productFetchOption)
                     } else {
-                        await productModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
-                        await productModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                        await productSearchModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                        await productSearchModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
                     }
                 }
             }
@@ -255,7 +255,7 @@ extension SearchView {
                             .font(.napzakFont(.body5SemiBold14))
                             .applyNapzakTextStyle(napzakFontStyle: .body5SemiBold14)
                             .foregroundStyle(Color.napzakGrayScale(.gray900))
-                        Text(selectedTabIndex == 0 ? "\(productModel.sellProducts.count)개" : "\(productModel.buyProducts.count)개")
+                        Text(selectedTabIndex == 0 ? "\(productSearchModel.sellProducts.count)개" : "\(productSearchModel.buyProducts.count)개")
                             .font(.napzakFont(.body5SemiBold14))
                             .applyNapzakTextStyle(napzakFontStyle: .body5SemiBold14)
                             .foregroundStyle(Color.napzakPurple(.purple30))
@@ -280,24 +280,24 @@ extension SearchView {
                     
                     LazyVGrid(columns: columns, spacing: 20) {
                         if selectedTabIndex == 0 {
-                            ForEach(productModel.sellProducts) { product in
+                            ForEach(productSearchModel.sellProducts) { product in
                                 NavigationLink(destination: ProductDetailView()) {
                                     ProductItemView(
                                         product: product,
                                         width: width
                                     )
-                                    .environmentObject(productModel)
+                                    .environmentObject(productSearchModel)
                                 }
                             }
                         }
                         else if selectedTabIndex == 1 {
-                            ForEach(productModel.buyProducts) { product in
+                            ForEach(productSearchModel.buyProducts) { product in
                                 NavigationLink(destination: ProductDetailView()) {
                                     ProductItemView(
                                         product: product,
                                         width: width
                                     )
-                                    .environmentObject(productModel)
+                                    .environmentObject(productSearchModel)
                                 }
                             }
                         }
@@ -312,24 +312,24 @@ extension SearchView {
                 Task {
                     if searchResultText.isEmpty {
                         if isFiltered {
-                            await productModel.getBuyProducts(productFetchOption: productFetchOption)
-                            await productModel.getSellProducts(productFetchOption: productFetchOption)
+                            await productSearchModel.getBuyProducts(productFetchOption: productFetchOption)
+                            await productSearchModel.getSellProducts(productFetchOption: productFetchOption)
                         } else {
                             if selectedTabIndex == 0 {
-                                await productModel.getBuyProducts(productFetchOption: productFetchOption)
+                                await productSearchModel.getBuyProducts(productFetchOption: productFetchOption)
                             } else if selectedTabIndex == 1 {
-                                await productModel.getSellProducts(productFetchOption: productFetchOption)
+                                await productSearchModel.getSellProducts(productFetchOption: productFetchOption)
                             }
                         }
                     } else {
                         if isFiltered {
-                            await productModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
-                            await productModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                            await productSearchModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                            await productSearchModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
                         } else {
                             if selectedTabIndex == 0 {
-                                await productModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                                await productSearchModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
                             } else if selectedTabIndex == 1 {
-                                await productModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                                await productSearchModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
                             }
                         }
                     }
@@ -342,15 +342,15 @@ extension SearchView {
                 Task {
                     if searchResultText.isEmpty {
                         if selectedTabIndex == 0 {
-                            await productModel.getSellProducts(productFetchOption: productFetchOption)
+                            await productSearchModel.getSellProducts(productFetchOption: productFetchOption)
                         } else if selectedTabIndex == 1 {
-                            await productModel.getBuyProducts(productFetchOption: productFetchOption)
+                            await productSearchModel.getBuyProducts(productFetchOption: productFetchOption)
                         }
                     } else {
                         if selectedTabIndex == 0 {
-                            await productModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                            await productSearchModel.getSellProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
                         } else if selectedTabIndex == 1 {
-                            await productModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
+                            await productSearchModel.getBuyProductsForSearch(searchWord: searchResultText, productFetchOption: productFetchOption)
                         }
                     }
                 }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
@@ -7,6 +7,26 @@
 
 import SwiftUI
 
+enum SortOption: String {
+    case recent = "RECENT"
+    case popular = "POPULAR"
+    case highPrice = "HIGH_PRICE"
+    case lowPrice = "LOW_PRICE"
+    
+    var title: String {
+        switch self {
+        case .recent:
+            return "최근순"
+        case .popular:
+            return "인기순"
+        case .highPrice:
+            return "고가순"
+        case .lowPrice:
+            return "저가순"
+        }
+    }
+}
+
 struct SearchView: View {
     
     //MARK: - Property Wrappers
@@ -20,14 +40,12 @@ struct SearchView: View {
     //세그먼트 컨트롤
     @State var selectedTabIndex = 0
     
-    //정렬
-    @State var selectedSortOption: SortOption = .latest
-    
     //필터
     @State var adaptedGenres: [GenreName] = []
     @State var selectedGenreStrings: [String] = []
-    @State var isSoldoutFilterOn = false
-    @State var isUnopenFilterOn = false
+    
+    //상품 분류
+    @State private var productFetchOption = ProductFetchOption(sortOption: .recent, genreIDs: [], isOnSale: false, isUnopened: false)
     
     //화면 전환
     @State var sortModalViewIsPresented = false
@@ -75,7 +93,7 @@ struct SearchView: View {
                             
                             SortModalView(
                                 sortModalViewIsPresented: $sortModalViewIsPresented,
-                                selectedSortOption: $selectedSortOption
+                                selectedSortOption: $productFetchOption.sortOption
                             )
                         } else if filterModalViewIsPresented {
                             Color.napzakTransparency(.black70)
@@ -188,9 +206,9 @@ extension SearchView {
                 
                 Button {
                     print("품절 제외 필터 선택")
-                    isSoldoutFilterOn.toggle()
+                    productFetchOption.isOnSale.toggle()
                 } label: {
-                    Image(isSoldoutFilterOn ? .chipSoldoutSelect : .chipSoldout)
+                    Image(productFetchOption.isOnSale ? .chipSoldoutSelect : .chipSoldout)
                         .resizable()
                         .frame(width: 69, height: 33)
                 }
@@ -198,14 +216,14 @@ extension SearchView {
                 if selectedTabIndex == 0 {
                     Button {
                         print("미개봉 필터 선택")
-                        isUnopenFilterOn.toggle()
+                        productFetchOption.isUnopened.toggle()
                     } label: {
-                        Image(isUnopenFilterOn ? .chipUnopenSelect : .chipUnopen)
+                        Image(productFetchOption.isUnopened ? .chipUnopenSelect : .chipUnopen)
                             .resizable()
                             .frame(width: 59, height: 33)
                     }
+                    Spacer()
                 }
-                Spacer()
             }
         }
         .frame(height: 53)
@@ -234,7 +252,7 @@ extension SearchView {
                             sortModalViewIsPresented = true
                         } label: {
                             HStack(spacing: 0) {
-                                Text("\(selectedSortOption.rawValue)")
+                                Text("\(productFetchOption.sortOption.title)")
                                     .font(.napzakFont(.caption3Medium12))
                                     .applyNapzakTextStyle(napzakFontStyle: .caption3Medium12)
                                     .foregroundStyle(Color.napzakGrayScale(.gray600))

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Search/View/SearchView.swift
@@ -45,7 +45,7 @@ struct SearchView: View {
     @State var selectedGenreStrings: [String] = []
     
     //상품 분류
-    @State private var productFetchOption = ProductFetchOption(sortOption: .recent, genreIDs: [], isOnSale: false, isUnopened: false)
+    @State var productFetchOption = ProductFetchOption(sortOption: .recent, genreIDs: [], isOnSale: false, isUnopened: false)
     
     //화면 전환
     @State var sortModalViewIsPresented = false
@@ -129,14 +129,8 @@ struct SearchView: View {
                     await productModel.getBuyProducts(productFetchOption: productFetchOption)
                 }
             }
-            .onChange(of: productFetchOption) { _ in
-                Task {
-                    if selectedTabIndex == 0 {
-                        await productModel.getSellProducts(productFetchOption: productFetchOption)
-                    } else if selectedTabIndex == 1 {
-                        await productModel.getBuyProducts(productFetchOption: productFetchOption)
-                    }
-                }
+            .onChange(of: adaptedGenres) { _ in
+                productFetchOption.genreIDs = adaptedGenres.map { $0.id }
             }
             .navigationBarHidden(true)
             .navigationDestination(isPresented: $searchInputViewIsPresented) {
@@ -314,6 +308,16 @@ extension SearchView {
                         await productModel.getBuyProducts(productFetchOption: productFetchOption)
                     } else if selectedTabIndex == 1 {
                         await productModel.getSellProducts(productFetchOption: productFetchOption)
+                    }
+                }
+            }
+            .onChange(of: productFetchOption) { _ in
+                proxy.scrollTo("header", anchor: .top)
+                Task {
+                    if selectedTabIndex == 0 {
+                        await productModel.getSellProducts(productFetchOption: productFetchOption)
+                    } else if selectedTabIndex == 1 {
+                        await productModel.getBuyProducts(productFetchOption: productFetchOption)
                     }
                 }
             }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #61


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
탐색 탭 상품 목록 조회 UI 구현했습니다잉

- `ProductSearchModel` 생성했숨다.
- 서버 호출 시 파라미터 의 Bool값과 enum 처리값, 장르 아이디 배열에 따라 호출되는 목록이 다르기 때문에 `ProductFetchOption`이라는 구조체를 정의하여 핸들링했습니다.

  ```
  @State var productFetchOption = ProductFetchOption(sortOption: .recent, genreIDs: [], isOnSale: false, isUnopened: false)
  ```
  뷰 내부에 서 `@State`변수로  선언하여 내부 요소의 값이 변할 때마다 서버를 호출하도록 구현했습니다!

- 탭 변경시에 파라미터 값을 유지한 채로 스크롤을 올리고, 정렬 기준을 바꿔야하기 때문에 sortOption옵션을 제외한 나머지 값이 존재하거나 true값일 때의 상태를 저장하여 사용할 수 있도록 했습니다~!

## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
뷰가 많이 복잡해서 이해 안되는 부분 질문 바로 ㄱㄱㄱㄱ해주세용

## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|장르 모달에서 적용|검색 화면에서 적용|
|:--:|:--:|
|<img src = "https://github.com/user-attachments/assets/e95ecff9-1564-467f-a0d6-18965ee3e3e1" width ="250">|<img src = "https://github.com/user-attachments/assets/742a360e-3f85-49dc-936b-2f57d2bccb7e" width ="250">|

## 📟 관련 이슈
- Resolved: #61
