### PR TITLE
[Fix] #92 - 디자인 QA 

### DIFF
--- a/Napzakmarket-iOS/Napzakmarket-iOS/Global/Components/SegmentedControl/NZSegmentedControl.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Global/Components/SegmentedControl/NZSegmentedControl.swift
@@ -57,7 +57,7 @@ extension NZSegmentedControl {
                         Text(tabs[i])
                             .font(selectedIndex == i ? .napzakFont(.title5SemiBold18) : .napzakFont(.title6Medium18))
                             .applyNapzakTextStyle(napzakFontStyle: .title5SemiBold18)
-                            .foregroundStyle(selectedIndex == i ? Color.napzakPurple(.purple30): Color.napzakGrayScale(.gray300))
+                            .foregroundStyle(selectedIndex == i ? Color.napzakPurple(.purple30): Color.napzakGrayScale(.gray600))
                         Divider()
                             .frame(height: 2)
                             .overlay(selectedIndex == i ? Color.napzakPurple(.purple30): Color.napzakGrayScale(.gray300))

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Home/View/HomeView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Home/View/HomeView.swift
@@ -83,7 +83,7 @@ struct HomeView: View {
                             .padding(.leading, 20)
                     }
                     .padding(.top, 26)
-                    .padding(.bottom, 165)
+                    .padding(.bottom, 75)
                 }
             }
         }

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Market/View/MarketView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Market/View/MarketView.swift
@@ -189,7 +189,8 @@ struct MarketView: View {
                 HStack(spacing: 6) {
                     ForEach(storeInfo.genrePreferences, id: \.id) { genre in
                         Text(genre.genreName)
-                            .font(.system(size: 12))
+                            .font(.napzakFont(.caption3Medium12))
+                            .applyNapzakTextStyle(napzakFontStyle: .caption3Medium12)
                             .foregroundColor(Color.napzakGrayScale(.gray800))
                             .padding(.horizontal, 8)
                             .padding(.vertical, 4)

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Mypage/View/MypageView.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Mypage/View/MypageView.swift
@@ -102,7 +102,6 @@ struct MyPageView: View {
             marketButton
         }
         .padding(20)
-        .frame(width: 360)
         .background(Color.napzakGrayScale(.white))
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .overlay(
@@ -110,7 +109,8 @@ struct MyPageView: View {
                 .inset(by: 0.5)
                 .stroke(Color.napzakGrayScale(.gray200), lineWidth: 1)
         )
-        .padding(.top, 20)
+        .padding(.top,20)
+        .padding(.horizontal, 20)
     }
         
     private var marketButton: some View {

--- a/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Tabbar/Model/TabBarModel.swift
+++ b/Napzakmarket-iOS/Napzakmarket-iOS/Presentation/Tabbar/Model/TabBarModel.swift
@@ -21,7 +21,7 @@ extension TabItem {
             TabItem(title: "홈", defaultIcon: "ic_home", selectedIcon: "ic_home_select", view: AnyView(HomeView())),
             TabItem(title: "탐색", defaultIcon: "ic_look", selectedIcon: "ic_look_select", view: AnyView(SearchView())),
             TabItem(title: "등록", defaultIcon: "ic_register", selectedIcon: "ic_register_select", view: AnyView(EmptyView())),
-            TabItem(title: "채팅", defaultIcon: "ic_chat", selectedIcon: "ic_chat_select", view: AnyView(ReadyComponent())),
+            TabItem(title: "채팅", defaultIcon: "ic_chat", selectedIcon: "ic_chat_select", view: AnyView(ReadyComponent().padding(.top, 100))),
             TabItem(title: "마이", defaultIcon: "ic_my", selectedIcon: "ic_my_select", view: AnyView(MyPageView()))
         ]
     }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #92


## ✅ 작업한 내용
- [x] 탐색 팔아요/구해요 세그먼트 바 선택되지 않은 텍스트 너무 연함 gray600 맞는지 체크
- [x] 팔아요 등록에 있는 배송비 토글 회색 박스와 그 안에 있는 흰색 박스의 마진값이 상하좌우 동일해야 함 지금은 상하보다 좌우가 더 가까워 보임
- [x] 채팅 준비중이에요 캐릭터랑 텍스트 살짝 높아보이는데 20px정도만 내려주실 수 있는지? ㅠㅠ (판매/구매 내역 관심장르 등등 눌렀을 때 뜨는 준비중이에요는 괜찮음)
- [x] 마이페이지 프로필/닉네임/내마켓보기 있는 박스 양옆 마진값 안 맞음 (좁아보임)
- [x] 내 마켓 보기에서 관심장르 칩이랑 아래 소개글이랑 텍스트 스타일 같은건데 크기랑 굵기가 달라보임 …! 
- [x] 홈화면 하단 여백 줄이기


## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #이슈번호
